### PR TITLE
Feat/designdoc updates and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_ISSUE.md
@@ -1,0 +1,21 @@
+---
+    name: Bug Report
+    about: Report an issue found in the DSNP example client
+    title: ""
+    labels: "bug"
+    assignees: ""
+---
+Issue description
+---------------
+A short description of bug and what you believe the intended outcome should have been.
+Thanks for reporting an issue!
+
+Expected vs. Actual
+---------------
+- A description of what you expected
+- A description of what happened instead
+
+Additional details / screenshot
+---------------
+- Any supplemental pictures or material
+- ![Screenshot]()

--- a/.github/ISSUE_TEMPLATE/FEATURE_ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_ISSUE.md
@@ -1,0 +1,22 @@
+---
+    name: Feature Request
+    about: Request a new feature or feature expansion for the DSNP example client
+    title: ""
+    labels: "enhancement"
+    assignees: ""
+---
+
+
+Feature Description
+---------------
+A description of of the feature you want to add
+
+Feature Justification
+---------------
+A reason for why this feature should be added
+
+Acceptance Criteria
+---------------
+- [ ] a list of testable things
+- [ ] that should be there
+- [ ] if the feature is fully implemented.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+Purpose
+---------------
+tl;dr context for this pull request
+
+Related GitHub Issues
+---------------
+Mention the issues this is related to or addresses
+
+Solution
+---------------
+A short description of what you have done to implement/fix the above mentioned feature or bug
+
+@ any other developers who who worked on the PR with you
+
+
+Change summary
+---------------
+* A detailed list of bulleted
+* changes that go into detail about
+* the specifics of the changes
+* to the codebase
+
+
+Steps to Verify
+----------------
+1. A numbered list of steps
+2. To verify that this feature/bug
+3. is now working
+
+
+Additional details / screenshot
+----------------
+- Any supplemental pictures or material
+- ![Screenshot]()

--- a/DESIGN_DOCS.md
+++ b/DESIGN_DOCS.md
@@ -1,5 +1,7 @@
 # Design Documents
 
+* [Design Doc Template](https://github.com/LibertyDSNP/meta/blob/main/templates/DESIGN_DOC_TEMPLATE.md)
+
 ## Purposes of this document
 * To describe what our design documents are for, their structure, and what goes in them.
 * To describe how DSNP Design Documents are produced and where they're published.

--- a/DESIGN_DOCS.md
+++ b/DESIGN_DOCS.md
@@ -4,10 +4,21 @@
 * To describe what our design documents are for, their structure, and what goes in them.
 * To describe how DSNP Design Documents are produced and where they're published.
 
-## What Is a Design Document?
-It's a document clearly describing a problem, a solution to that problem, and why we think the proposal is the right solution.
+## What is a Design Document?
+It's a document clearly describing a problem or feature, a solution for it, and why we think the proposal is the right solution.
+We'll use _"problem"_ here to broadly mean "anything that means we need to write some code."
 It has enough information to begin writing stories for implementing the solution in the document.
- 
+
+## When do we expect a Design Document?
+Generally we expect to see a Design Document when the solution is neither simple nor obvious to a developer with domain knowledge of the problem.
+If the solution will result in more than one reasonably-sized Issue, that is a sign a Design Document might be needed.
+
+**Examples that don't need a Design Document:** Major revisions to a README file, bug fixes (usually), implementing a login screen.
+
+**Examples that need a Design Document:** A serious security flaw that requires rewriting an entire library, a new API.  
+
+Always use your best judgment.
+
 ## Audience
 The audience for DSNP Design Documents is mainly DSNP developers from multiple organizations.
 We also expect other developers and technically savvy readers will read these documents. 
@@ -25,8 +36,8 @@ These sections should be in the order that they are described here.
     That means it won't be a separate package, and the code will be tailored for this repo.
     One might also say that the scope is also limited to developer testing, so it's not meant to be used in CI or a test environment such as a test blockchain network.
 * **Problem Statement**: The "why." A short summary of the issue(s) that this design solves.
-    This doesn't have to be a technical problem. 
-    "Developer unhappiness" or "improved user experience" are also problems.
+    This doesn't have to be a technical problem, and it doesn't have to be a literal "problem." 
+    "Developer unhappiness", "user experience needs improvement", and  are also problems.
 * **Goals and Non-goals**:  what this solution is trying to do, and is also _not_ trying to do, in concrete terms.  Measurable goals are best.
 * **Glossary** (optional): if you think inline links to concepts are too distracting, include a glossary section.
     This can be links, text or both.

--- a/DESIGN_DOCS.md
+++ b/DESIGN_DOCS.md
@@ -39,7 +39,8 @@ These sections should be in the order that they are described here.
     One might also say that the scope is also limited to developer testing, so it's not meant to be used in CI or a test environment such as a test blockchain network.
 * **Problem Statement**: The "why." A short summary of the issue(s) that this design solves.
     This doesn't have to be a technical problem, and it doesn't have to be a literal "problem." 
-    "Developer unhappiness", "user experience needs improvement", and  are also problems.
+    It could also be a necessary feature.
+    "Developer unhappiness", "user experience needs improvement", are also problems.
 * **Goals and Non-goals**:  what this solution is trying to do, and is also _not_ trying to do, in concrete terms.  Measurable goals are best.
 * **Glossary** (optional): if you think inline links to concepts are too distracting, include a glossary section.
     This can be links, text or both.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,47 @@
-This template outlines the basic structure that README.md files across Project 
-Liberty should generally have. Not all components will be relevant for all work.
-Think what questions your audience might have and try to answer them in the 
-README.md file. 
+This template outlines the basic structure that README.md files across Project Liberty should generally have.
+Not all components will be relevant for all work. 
+Think what questions your audience might have and try to answer them in the README.md file. 
+
+## Table of Contents (Optional)
+If the README is more than a couple of pages long, help readers easily find what they need by adding a table of contents, like the following:
+
+* [Overview](https://github.com/LibertyDSNP/meta#overview)
+* [Installation](https://github.com/LibertyDSNP/meta#installation)
+* [Dependencies/Requirements](https://github.com/LibertyDSNP/meta#dependenciesrequirements)
+* [Configuration](https://github.com/LibertyDSNP/meta#configuration)
+* [Examples](https://github.com/LibertyDSNP/meta#examples)
+* [Roadmap](https://github.com/LibertyDSNP/meta#roadmap)
+* [Support](https://github.com/LibertyDSNP/meta#support)
+* [Contributing](https://github.com/LibertyDSNP/meta#contributing)
 
 ## Overview 
 A brief description of the work and the intended audience. 
 
 ## Installation 
-A concise but thorough, step-by-step installation guide, written for a someone 
-new to the work.
+A concise but thorough, step-by-step installation guide, written for a someone new to the work.
 
 ## Dependencies/Requirements
-List any external dependencies or requirements for running the work. For example, 
-updates to the DSNP.org web site requires the use of the Ghost CMS, which is not 
-managed by Project Liberty. 
+List any external dependencies or requirements for running the work. For example, updates to the DSNP.org web site requires the use of the Ghost CMS, which is not managed by Project Liberty. 
 
 ## Configuration
 List any useful configuration tips. 
 
 ## Examples
-Share examples of how this work could be put into practice. Code examples and 
-screenshots are helpful.
+Share examples of how this work could be put into practice. Code examples and screenshots are helpful.
 
 ## Roadmap
 If available, highlight an at-a-glance roadmap for future development. 
 
 ## Support
-Direct the audience to the [Project Liberty Forums](https://forums.projectliberty.io/)
-or to file a GitHub Issue. If available and it's part of your workflow, include 
-a project-specific email. 
+Direct the audience to the [Project Liberty Forums](https://forums.projectliberty.io/) or to file a GitHub Issue. If available and it's part of your workflow, include a project-specific email. 
 
 ## Contributing
 We welcome contributions of code and documentation.  Please see
 [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute.  
 
-*(That will usually link to the project's local `CONTRIBUTING.md`
-file, which provides any project-specific contribution instructions
-and links out to the [Project Liberty global
+*(That will usually link to the project's local `CONTRIBUTING.md` file, which provides any project-specific contribution instructions and links out to the [Project Liberty global
 CONTRIBUTING.md](https://github.com/LibertyDSNP/meta/blob/main/CONTRIBUTING.md)
-for general guidelines.  But if there are no project-specific
-contribution instructions, then just link directly to the [global
+for general guidelines.  But if there are no project-specific contribution instructions, then just link directly to the [global
 CONTRIBUTING.md](https://github.com/LibertyDSNP/meta/blob/main/CONTRIBUTING.md)
 from here.)*
 

--- a/templates/BUG_ISSUE.md
+++ b/templates/BUG_ISSUE.md
@@ -5,33 +5,26 @@
     labels: "bug"
     assignees: ""
 ---
-Issue description
----------------
+
+## Issue description
 A short description of bug and what you believe the intended outcome should have been.
 Thanks for reporting an issue!
 
-
-Reproduce Issue
----------------
+## How to reproduce the issue
 1. A list of steps
-2. to recreate the
-3. bug or issue
+2. Or a unit test if possible
+3. that reproduces the bug or issue
 
-Tech Versions
----------------
+## Tech Versions
 - Browser:
 - OS:
 - Wallet:
 
-Expected result
----------------
+## Expected result
 - A detailed description of what you expected to happen
 
-
-Actual result
----------------
+## Actual result
 - A detailed description of what actually happened
-
 
 Additional details / screenshot
 ---------------

--- a/templates/BUG_ISSUE.md
+++ b/templates/BUG_ISSUE.md
@@ -1,0 +1,39 @@
+---
+    name: Bug Report
+    about: Report an issue found in the DSNP example client
+    title: ""
+    labels: "bug"
+    assignees: ""
+---
+Issue description
+---------------
+A short description of bug and what you believe the intended outcome should have been.
+Thanks for reporting an issue!
+
+
+Reproduce Issue
+---------------
+1. A list of steps
+2. to recreate the
+3. bug or issue
+
+Tech Versions
+---------------
+- Browser:
+- OS:
+- Wallet:
+
+Expected result
+---------------
+- A detailed description of what you expected to happen
+
+
+Actual result
+---------------
+- A detailed description of what actually happened
+
+
+Additional details / screenshot
+---------------
+- Any supplemental pictures or material
+- ![Screenshot]()

--- a/templates/DESIGN_DOC_TEMPLATE.md
+++ b/templates/DESIGN_DOC_TEMPLATE.md
@@ -1,0 +1,24 @@
+# Design Doc Title
+Please see the [Design Doc README](https://github.com/LibertyDSNP/meta/blob/main/DESIGN_DOCS.md) for details on what goes in each section.
+
+## Table of Contents (Optional)
+* [Glossary](https://github.com/LibertyDSNP/meta#overview)
+* [Context and Scope](https://github.com/LibertyDSNP/meta#installation)
+* [Problem Statement](https://github.com/LibertyDSNP/meta#dependenciesrequirements)
+* [Goals and Non-Goals](https://github.com/LibertyDSNP/meta#configuration)
+* [Proposal](https://github.com/LibertyDSNP/meta#examples)
+* [Benefits and Risks](https://github.com/LibertyDSNP/meta#roadmap)
+* [Alternatives and Rationale](https://github.com/LibertyDSNP/meta#support)
+* [Additional Resources](https://github.com/LibertyDSNP/meta#contributing)
+
+## Glossary (Optional)
+* **term**: definition
+## Context and Scope
+## Problem Statement
+## Goals and Non-Goals
+## Proposal
+## Benefits and Risks
+## Alternatives and Rationale
+## Additional Resources
+
+* [Source name](http://www...) with description

--- a/templates/FEATURE_ISSUE.md
+++ b/templates/FEATURE_ISSUE.md
@@ -6,27 +6,17 @@
     assignees: ""
 ---
 
-
-Feature Description
----------------
+## Feature Description
 A description of of the feature you want to add
 
-
-Feature Justification
----------------
+## Feature Justification
 A reason for why this feature should be added
 
+## Acceptance Criteria
+- [ ] a list of testable things
+- [ ] that should exist or occur
+- [ ] if the feature is fully implemented
 
-Acceptance Criteria
----------------
-1. A list of steps
-2. to follow that
-3. should all be true
-4. if the feature is
-5. implemented properly
-
-
-Additional details / screenshot
----------------
+## Additional details / screenshot
 - Any supplemental pictures or material
 - ![Screenshot]()

--- a/templates/FEATURE_ISSUE.md
+++ b/templates/FEATURE_ISSUE.md
@@ -1,0 +1,32 @@
+---
+    name: Feature Request
+    about: Request a new feature or feature expansion for the DSNP example client
+    title: ""
+    labels: "enhancement"
+    assignees: ""
+---
+
+
+Feature Description
+---------------
+A description of of the feature you want to add
+
+
+Feature Justification
+---------------
+A reason for why this feature should be added
+
+
+Acceptance Criteria
+---------------
+1. A list of steps
+2. to follow that
+3. should all be true
+4. if the feature is
+5. implemented properly
+
+
+Additional details / screenshot
+---------------
+- Any supplemental pictures or material
+- ![Screenshot]()

--- a/templates/PULL_REQUEST_TEMPLATE.md
+++ b/templates/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,24 @@
-Purpose
----------------
-tl;dr context for this pull request
+# Purpose
+Summary for this pull request
 
-Related GitHub Issues
----------------
-Mention the issues this is related to or addresses
+Closes #1 <-- Reference an existing issue using this format with the Issue number, and it will be closed automatically when the PR is merged.
 
-Solution
----------------
+## Solution
 A short description of what you have done to implement/fix the above mentioned feature or bug
 
-@ any other developers who who worked on the PR with you
+@reference any other developers who who worked on the PR with you
 
-
-Change summary
----------------
+## Change summary
 * A detailed list of bulleted
 * changes that go into detail about
 * the specifics of the changes
 * to the codebase
 
-
-Steps to Verify
-----------------
+## Steps to Verify
 1. A numbered list of steps
 2. To verify that this feature/bug
 3. is now working
 
-
-Additional details / screenshot
-----------------
+## Additional details / screenshot
 - Any supplemental pictures or material
 - ![Screenshot]()

--- a/templates/PULL_REQUEST_TEMPLATE.md
+++ b/templates/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+Purpose
+---------------
+tl;dr context for this pull request
+
+Related GitHub Issues
+---------------
+Mention the issues this is related to or addresses
+
+Solution
+---------------
+A short description of what you have done to implement/fix the above mentioned feature or bug
+
+@ any other developers who who worked on the PR with you
+
+
+Change summary
+---------------
+* A detailed list of bulleted
+* changes that go into detail about
+* the specifics of the changes
+* to the codebase
+
+
+Steps to Verify
+----------------
+1. A numbered list of steps
+2. To verify that this feature/bug
+3. is now working
+
+
+Additional details / screenshot
+----------------
+- Any supplemental pictures or material
+- ![Screenshot]()

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,9 @@
+# Meta Templates
+There are several templates here which can be copied and used in other LibertyDSNP repos.
+
+Please use [DESIGN_DOC_TEMPLATE.md](https://github.com/LibertyDSNP/meta/blob/main/templates/DESIGN_DOC_TEMPLATE.md) for all Design Documents.
+
+Please modify as appropriate for the repo:
+* [PULL_REQUEST_TEMPLATE.md](https://github.com/LibertyDSNP/meta/blob/main/templates/PULL_REQUEST_TEMPLATE.md)
+* [BUG_ISSUE.md](https://github.com/LibertyDSNP/meta/blob/main/templates/BUG_ISSUE.md)
+* [FEATURE_ISSUE.md](https://github.com/LibertyDSNP/meta/blob/main/templates/FEATURE_ISSUE.md)


### PR DESCRIPTION
# Problem
We could use some templates to copy and paste to our repos so we can have a generally consistent style across repos.  A design doc template is the main one but I thought we could use PR, Issue and Feature templates too.

# Solution
* Add some of those templates, and also use them in this repo (pull request, issue and feature templates).  I pulled the ones in from [example-client](https://github.com/LibertyDSNP/example-client).
* Update some other templates, e.g. adding a Table of Contents to the main README.

Please have a look at the new templates, not to be set in stone but edited as needed for a given repo.  