### PR TITLE
Use relative links where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Think what questions your audience might have and try to answer them in the READ
 ## Table of Contents (Optional)
 If the README is more than a couple of pages long, help readers easily find what they need by adding a table of contents, like the following:
 
-* [Overview](https://github.com/LibertyDSNP/meta#overview)
-* [Installation](https://github.com/LibertyDSNP/meta#installation)
-* [Dependencies/Requirements](https://github.com/LibertyDSNP/meta#dependenciesrequirements)
-* [Configuration](https://github.com/LibertyDSNP/meta#configuration)
-* [Examples](https://github.com/LibertyDSNP/meta#examples)
-* [Roadmap](https://github.com/LibertyDSNP/meta#roadmap)
-* [Support](https://github.com/LibertyDSNP/meta#support)
-* [Contributing](https://github.com/LibertyDSNP/meta#contributing)
+* [Overview](#overview)
+* [Installation](#installation)
+* [Dependencies/Requirements](#dependenciesrequirements)
+* [Configuration](#configuration)
+* [Examples](#examples)
+* [Roadmap](#roadmap)
+* [Support](#support)
+* [Contributing](#contributing)
 
 ## Overview 
 A brief description of the work and the intended audience. 

--- a/templates/DESIGN_DOC_TEMPLATE.md
+++ b/templates/DESIGN_DOC_TEMPLATE.md
@@ -2,14 +2,14 @@
 Please see the [Design Doc README](https://github.com/LibertyDSNP/meta/blob/main/DESIGN_DOCS.md) for details on what goes in each section.
 
 ## Table of Contents (Optional)
-* [Glossary](https://github.com/LibertyDSNP/meta#overview)
-* [Context and Scope](https://github.com/LibertyDSNP/meta#installation)
-* [Problem Statement](https://github.com/LibertyDSNP/meta#dependenciesrequirements)
-* [Goals and Non-Goals](https://github.com/LibertyDSNP/meta#configuration)
-* [Proposal](https://github.com/LibertyDSNP/meta#examples)
-* [Benefits and Risks](https://github.com/LibertyDSNP/meta#roadmap)
-* [Alternatives and Rationale](https://github.com/LibertyDSNP/meta#support)
-* [Additional Resources](https://github.com/LibertyDSNP/meta#contributing)
+* [Glossary](#glossary)
+* [Context and Scope](#context-and-scope)
+* [Problem Statement](#problem-statement)
+* [Goals and Non-Goals](#goals-and-non-goals)
+* [Proposal](#proposal)
+* [Benefits and Risks](#benefits-and-risks)
+* [Alternatives and Rationale](#alternatives-and-rationale)
+* [Additional Resources](#additional-resources)
 
 ## Glossary (Optional)
 * **term**: definition


### PR DESCRIPTION
Convert some, but not all, links from absolute to relative.  (Because
this is the 'meta' repository, there are still some places where using
an absolute link makes sense, since these files may be copied to other
repositories and used from there.)

In 'templates/DESIGN_DOC_TEMPLATE.md', change from absolute to
relative and fix the relative target anchor names as well.

Related GitHub Issues
---------------

No related issues, but I found this while doing *post facto* review of PR #8.
