### PR TITLE
In PR template, mention doc changes too

### DIFF
--- a/templates/PULL_REQUEST_TEMPLATE.md
+++ b/templates/PULL_REQUEST_TEMPLATE.md
@@ -8,16 +8,22 @@ A short description of what you have done to implement/fix the above mentioned f
 
 @reference any other developers who who worked on the PR with you
 
+If this is a documentation-only PR, this section can describe the motivation for the changes, or can be omitted if the motivation is obvious.
+
 ## Change summary
 * A detailed list of bulleted
 * changes that go into detail about
 * the specifics of the changes
 * to the codebase
 
+If this PR contains code changes that imply accompanying documentation changes, please include the documentation changes in the same PR.
+
 ## Steps to Verify
 1. A numbered list of steps
 2. To verify that this feature/bug
 3. is now working
+
+(This section can be omitted for documentation-only PRs, since they tend to be more self-explanatory than code changes.)
 
 ## Additional details / screenshot
 - Any supplemental pictures or material


### PR DESCRIPTION
Purpose
---------------

Help people remember to update documentation when making code changes.  Relatedly, offer some guidance regarding documentation-only PRs.
