### PR TITLE
Fix broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ A few useful resources:
 
 - General Questions + Support: [See the Forums](https://forums.projectliberty.io/)
 - [Project Liberty Whitepaper on DSNP](https://unfinished.com/wp-content/uploads/dsnp_whitepaper.pdf)
-- [DSNP Roadmap](https://spec.dsnp.org/#implementation-status)
-- [DSNP Dev Portal](https://www.dsnp.org/dev-portal-introduction/)
+- [DSNP Spec](https://spec.dsnp.org/)
+- [DSNP Introduction](https://dsnp.org/introducing-dsnp.html)
 - Submit a bug: see Submitting Issues below
 
 ## Code of Conduct


### PR DESCRIPTION
Purpose
---------------
It seems `#implementation-status` and `/dev-portal-introduction` are no longer valid.

Solution
---------------
Re-pointing the link target and description to nearby content.

Steps to Verify
----------------
1. Click links in CONTRIBUTING.md and see it now points to somewhere valid.

